### PR TITLE
fix: make captures more specific so they show up in symbol palette

### DIFF
--- a/Bats.sublime-syntax
+++ b/Bats.sublime-syntax
@@ -23,9 +23,9 @@ contexts:
   test-block:
     - match: (?<=\s|^)(@test)\s+(\"|\')(.*)(\"|\')(?=\s|$)
       captures:
-        1: storage.type.test-block.bats
+        1: storage.type.keyword.function.test-block.bats
         2: punctuation.definition.string.begin.bats
-        3: entity.name.test-block.bats
+        3: entity.name.function.test-block.bats
         4: punctuation.definition.string.end.bats
     - match: \{
       scope: punctuation.section.braces.begin.bats


### PR DESCRIPTION
Without these, the names of the entity don't show up.

Aside: even with these, I still don't know how to get it to show `function` or `test` as a prefix to the test name :(